### PR TITLE
Add PyTorch dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyarrow
 img2dataset
 tqdm
+torch


### PR DESCRIPTION
To use `torch.load` in `convert_parquet.py`, add `torch` to `requirement.txt`.